### PR TITLE
Add continuous voice mode and modernize UI

### DIFF
--- a/api_client.py
+++ b/api_client.py
@@ -71,12 +71,19 @@ class APIClient:
             "model": model,
             "temperature": 0.7,
             "max_tokens": 1024,
-            "stream": False
+            "stream": False,
         }
         try:
-            result = await self._request_json("POST", self.config.api_url, json=payload, timeout=aiohttp.ClientTimeout(total=30))
+            result = await self._request_json(
+                "POST",
+                self.config.api_url,
+                json=payload,
+                timeout=aiohttp.ClientTimeout(total=30),
+            )
         except asyncio.TimeoutError:
             return "Error: Request timed out"
+        finally:
+            await self.close()
         if isinstance(result, str):
             return result
         try:

--- a/windows_voice_chat.py
+++ b/windows_voice_chat.py
@@ -4,7 +4,7 @@ import re
 import tempfile
 import threading
 import tkinter as tk
-from tkinter import ttk, scrolledtext
+from tkinter import scrolledtext
 
 from gtts import gTTS
 from playsound import playsound
@@ -22,7 +22,7 @@ class VoiceChatApp:
         self.client = APIClient(self.config)
         self.root = tk.Tk()
         self.root.title("Unity Voice Chat")
-        self.root.configure(bg="#1a0000")
+        self.root.configure(bg="#000000")
 
         self.voice_enabled = tk.BooleanVar(value=True)
         self.selected_voice = tk.StringVar(value="en")
@@ -30,39 +30,82 @@ class VoiceChatApp:
             {"role": "system", "content": self.config.system_instructions}
         ]
 
+        self.listening = False
+        self.listen_thread: threading.Thread | None = None
+
         self._build_ui()
 
     def _build_ui(self):
-        top_frame = ttk.Frame(self.root)
+        top_frame = tk.Frame(self.root, bg="#000000")
         top_frame.pack(fill=tk.X, padx=5, pady=5)
 
-        voice_check = ttk.Checkbutton(
-            top_frame, text="Voice Output", variable=self.voice_enabled
+        voice_check = tk.Checkbutton(
+            top_frame,
+            text="Voice Output",
+            variable=self.voice_enabled,
+            bg="#000000",
+            fg="#FF0000",
+            selectcolor="#000000",
+            activebackground="#000000",
+            activeforeground="#FF0000",
         )
         voice_check.pack(side=tk.LEFT)
 
         voices = self._available_voices()
-        voice_menu = ttk.OptionMenu(
+        voice_menu = tk.OptionMenu(
             top_frame, self.selected_voice, self.selected_voice.get(), *voices
         )
+        voice_menu.configure(
+            bg="#330000",
+            fg="#FF0000",
+            activebackground="#660000",
+            activeforeground="#FF0000",
+            highlightthickness=0,
+        )
         voice_menu.pack(side=tk.LEFT, padx=5)
+        voice_menu["menu"].config(bg="#000000", fg="#FF0000")
 
-        speak_button = ttk.Button(top_frame, text="Speak", command=self._voice_input)
-        speak_button.pack(side=tk.LEFT, padx=5)
+        self.start_button = tk.Button(
+            top_frame,
+            text="Start Talking",
+            command=self._toggle_listening,
+            bg="#330000",
+            fg="#FF0000",
+            activebackground="#660000",
+            activeforeground="#FF0000",
+        )
+        self.start_button.pack(side=tk.LEFT, padx=5)
 
         self.text_area = scrolledtext.ScrolledText(
-            self.root, wrap=tk.WORD, state=tk.DISABLED, bg="#330000", fg="#FFFFFF"
+            self.root,
+            wrap=tk.WORD,
+            state=tk.DISABLED,
+            bg="#000000",
+            fg="#FF0000",
         )
         self.text_area.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
 
-        bottom_frame = ttk.Frame(self.root)
+        bottom_frame = tk.Frame(self.root, bg="#000000")
         bottom_frame.pack(fill=tk.X, padx=5, pady=5)
 
-        self.entry = ttk.Entry(bottom_frame)
+        self.entry = tk.Entry(
+            bottom_frame,
+            bg="#000000",
+            fg="#FF0000",
+            insertbackground="#FF0000",
+        )
         self.entry.pack(side=tk.LEFT, fill=tk.X, expand=True)
         self.entry.bind("<Return>", lambda event: self._send_text())
 
-        send_button = ttk.Button(bottom_frame, text="Send", command=self._send_text)
+        send_button = tk.Button(
+            bottom_frame,
+            text="Send",
+            command=self._send_text,
+            bg="#330000",
+            fg="#FF0000",
+            activebackground="#660000",
+            activeforeground="#FF0000",
+        )
         send_button.pack(side=tk.LEFT, padx=5)
 
     def _available_voices(self):
@@ -86,22 +129,32 @@ class VoiceChatApp:
         self.messages.append({"role": "user", "content": text})
         threading.Thread(target=self._get_response, args=(list(self.messages),)).start()
 
-    def _voice_input(self):
-        threading.Thread(target=self._listen_and_send).start()
+    def _toggle_listening(self):
+        if not self.listening:
+            self.listening = True
+            self.start_button.config(text="Stop Talking")
+            self.listen_thread = threading.Thread(target=self._listen_loop, daemon=True)
+            self.listen_thread.start()
+        else:
+            self.listening = False
+            self.start_button.config(text="Start Talking")
 
-    def _listen_and_send(self):
+    def _listen_loop(self):
         r = sr.Recognizer()
         with sr.Microphone() as source:
-            audio = r.listen(source)
-        try:
-            text = r.recognize_google(audio, language=self.selected_voice.get())
-            self._append_text("You", text)
-            self.messages.append({"role": "user", "content": text})
-            self._get_response(list(self.messages))
-        except sr.UnknownValueError:
-            self._append_text("System", "Could not understand audio")
-        except sr.RequestError as e:
-            self._append_text("System", f"Speech recognition error: {e}")
+            while self.listening:
+                try:
+                    audio = r.listen(source, timeout=1, phrase_time_limit=5)
+                    text = r.recognize_google(audio, language=self.selected_voice.get())
+                    self._append_text("You", text)
+                    self.messages.append({"role": "user", "content": text})
+                    threading.Thread(target=self._get_response, args=(list(self.messages),)).start()
+                except sr.WaitTimeoutError:
+                    continue
+                except sr.UnknownValueError:
+                    self._append_text("System", "Could not understand audio")
+                except sr.RequestError as e:
+                    self._append_text("System", f"Speech recognition error: {e}")
 
     def _get_response(self, messages):
         try:


### PR DESCRIPTION
## Summary
- Add toggleable continuous listening button for hands-free voice conversations
- Refresh chat interface with sleek black and red theme
- Close API client session after each call to prevent event loop errors

## Testing
- `python -m py_compile windows_voice_chat.py api_client.py`


------
https://chatgpt.com/codex/tasks/task_b_68b0559324a083299f47c9d9ef7a8e27