### PR TITLE
Add missing Google Cloud Text-to-Speech dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 aiohttp
 gTTS
+google-cloud-texttospeech
 playsound
 SpeechRecognition
 pyaudio


### PR DESCRIPTION
## Summary
- Include `google-cloud-texttospeech` in requirements to enable speech synthesis

## Testing
- `pip install google-cloud-texttospeech`
- `python -m py_compile windows_voice_chat.py`


------
https://chatgpt.com/codex/tasks/task_b_68b0662e21ac8329824b8a85ef6e86e9