### PR TITLE
Fix ScrolledText style initialization error

### DIFF
--- a/windows_voice_chat.py
+++ b/windows_voice_chat.py
@@ -96,10 +96,12 @@ class VoiceChatApp:
             wrap=tk.WORD,
             state=tk.DISABLED,
             padding=5,
-            style="Neon.TFrame",
         )
+        self.text_area.configure(style="Neon.TFrame")
         self.text_area.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
-        self.text_area.text.configure(bg="black", fg=self.neon, insertbackground=self.neon)
+        self.text_area.text.configure(
+            bg="black", fg=self.neon, insertbackground=self.neon
+        )
 
         bottom_frame = ttk.Frame(self.root, padding=5, style="Neon.TFrame")
         bottom_frame.pack(fill=tk.X)


### PR DESCRIPTION
## Summary
- Avoid passing unsupported `style` option to `ScrolledText` and apply frame style after creation to prevent Tkinter `_tkinter.TclError`

## Testing
- `python -m py_compile windows_voice_chat.py`
- `python windows_voice_chat.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_b_68b06834c2fc8329907fedf15769cb19