### PR TITLE
Handle Pollinations URLs with spaces

### DIFF
--- a/windows_voice_chat.py
+++ b/windows_voice_chat.py
@@ -7,6 +7,7 @@ import time
 import tkinter as tk
 from tkinter import filedialog
 from io import BytesIO
+import urllib.parse
 
 import requests
 import ttkbootstrap as ttk
@@ -179,6 +180,22 @@ class VoiceChatApp:
         md_image_pattern = r"!\[[^\]]*\]\((https?://[^\s)]+)\)"
         images = re.findall(md_image_pattern, text)
         text = re.sub(md_image_pattern, "", text)
+
+        # Handle Pollinations image URLs that may contain spaces in the prompt.
+        pollinations_urls: list[str] = []
+
+        def _pollinations_repl(match: re.Match) -> str:
+            prompt = match.group(1).strip()
+            query = match.group(2)
+            encoded = urllib.parse.quote(prompt)
+            pollinations_urls.append(
+                f"https://image.pollinations.ai/prompt/{encoded}?{query}"
+            )
+            return ""
+
+        poll_pattern = r"https://image\.pollinations\.ai/prompt/([^?]+)\?([^\s]+)"
+        text = re.sub(poll_pattern, _pollinations_repl, text)
+        images += pollinations_urls
 
         # Also capture any remaining bare URLs
         url_pattern = r"(https?://[^\s]+)"


### PR DESCRIPTION
## Summary
- Ensure `_build_message` properly captures Pollinations image URLs when prompt text contains spaces.
- URL-encode Pollinations prompts and collect fixed links in the image list.

## Testing
- `python -m py_compile app_config.py api_client.py windows_voice_chat.py`


------
https://chatgpt.com/codex/tasks/task_b_68b0916fafd083298533def89e4def8d