### PR TITLE
Close session after fetching models to avoid event loop crash

### DIFF
--- a/api_client.py
+++ b/api_client.py
@@ -56,6 +56,7 @@ class APIClient:
         result = await self._request_json(
             "GET", self.config.models_url, headers=headers, timeout=15
         )
+        await self.close()
         if isinstance(result, list):
             if all(isinstance(m, str) for m in result):
                 return [{"name": m.strip()} for m in result]


### PR DESCRIPTION
## Summary
- close `APIClient` session after fetching models to prevent unclosed SSL transports

## Testing
- `python -m py_compile api_client.py`
- `python -m py_compile windows_voice_chat.py`


------
https://chatgpt.com/codex/tasks/task_b_68b09b6e2bb8832999062a062f9eb305