### PR TITLE
Replace async API client with synchronous requests

### DIFF
--- a/api_client.py
+++ b/api_client.py
@@ -1,49 +1,40 @@
-import aiohttp
-import random
-import asyncio
 import logging
-from typing import List, Dict, Any
+import random
+import time
+from typing import Any, Dict, List
+
+import requests
 
 logger = logging.getLogger(__name__)
 
 class APIClient:
     def __init__(self, config):
         self.config = config
-        self.session: aiohttp.ClientSession | None = None
         self.retry_attempts = 6
         self.retry_delay = 2
 
-    async def initialize(self) -> None:
-        if self.session is None or self.session.closed:
-            self.session = aiohttp.ClientSession()
-
-    async def close(self) -> None:
-        if self.session and not self.session.closed:
-            await self.session.close()
-            self.session = None
-
-    async def _request_json(self, method: str, url: str, **kwargs) -> Dict[str, Any] | str:
-        if self.session is None or self.session.closed:
-            await self.initialize()
+    def _request_json(self, method: str, url: str, **kwargs) -> Dict[str, Any] | str:
+        """Perform an HTTP request and return the parsed JSON or an error string."""
+        headers = kwargs.pop("headers", None)
         for attempt in range(self.retry_attempts):
             try:
-                async with self.session.request(method, url, **kwargs) as resp:
-                    if resp.status == 200:
-                        return await resp.json()
-                    if resp.status in {429, 500, 502, 503, 504}:
-                        delay = self.retry_delay * (2 ** attempt) + random.uniform(0, 0.1)
-                        logger.warning(f"Retry {attempt + 1}/{self.retry_attempts} status {resp.status} wait {delay:.2f}s")
-                        await asyncio.sleep(delay)
-                        continue
-                    try:
-                        error_text = await resp.text()
-                    except Exception:
-                        error_text = ""
-                    return f"Error: API returned status {resp.status} {error_text}"
-            except (aiohttp.ClientConnectionError, asyncio.TimeoutError) as e:
+                resp = requests.request(method, url, headers=headers, **kwargs)
+                if resp.status_code == 200:
+                    return resp.json()
+                if resp.status_code in {429, 500, 502, 503, 504}:
+                    delay = self.retry_delay * (2 ** attempt) + random.uniform(0, 0.1)
+                    logger.warning(
+                        f"Retry {attempt + 1}/{self.retry_attempts} status {resp.status_code} wait {delay:.2f}s"
+                    )
+                    time.sleep(delay)
+                    continue
+                return f"Error: API returned status {resp.status_code} {resp.text}"
+            except (requests.ConnectionError, requests.Timeout) as e:
                 delay = self.retry_delay * (2 ** attempt) + random.uniform(0, 0.1)
-                logger.warning(f"Retry {attempt + 1}/{self.retry_attempts} due to {e} wait {delay:.2f}s")
-                await asyncio.sleep(delay)
+                logger.warning(
+                    f"Retry {attempt + 1}/{self.retry_attempts} due to {e} wait {delay:.2f}s"
+                )
+                time.sleep(delay)
                 continue
             except Exception as e:
                 logger.error(f"Unexpected exception {e}")
@@ -51,39 +42,28 @@ class APIClient:
         logger.error("API unreachable after retries")
         return "Error: Upstream API unreachable after retries"
 
-    async def fetch_models(self) -> List[Dict[str, str]]:
+    def fetch_models(self) -> List[Dict[str, str]]:
         headers = {"Authorization": f"Bearer {self.config.pollinations_token}"}
-        result = await self._request_json(
-            "GET", self.config.models_url, headers=headers, timeout=15
-        )
-        await self.close()
+        result = self._request_json("GET", self.config.models_url, headers=headers, timeout=15)
         if isinstance(result, list):
             if all(isinstance(m, str) for m in result):
                 return [{"name": m.strip()} for m in result]
             if all(isinstance(m, dict) and "name" in m for m in result):
-                return [{"name": m["name"].strip(), "description": m.get("description", "")} for m in result]
+                return [
+                    {"name": m["name"].strip(), "description": m.get("description", "")}
+                    for m in result
+                ]
         return [{"name": "unity", "description": "Default unity model"}]
 
-    async def send_message(self, messages: list, model: str | None):
-        if self.session is None or self.session.closed:
-            await self.initialize()
+    def send_message(self, messages: list, model: str | None):
         if not model or not isinstance(model, str) or model.strip() == "":
             model = self.config.default_model
         logger.info(f"Using model: {model}")
         payload = {"messages": messages, "model": model}
         headers = {"Authorization": f"Bearer {self.config.pollinations_token}"}
-        try:
-            result = await self._request_json(
-                "POST",
-                self.config.api_url,
-                json=payload,
-                headers=headers,
-                timeout=aiohttp.ClientTimeout(total=30),
-            )
-        except asyncio.TimeoutError:
-            return "Error: Request timed out"
-        finally:
-            await self.close()
+        result = self._request_json(
+            "POST", self.config.api_url, json=payload, headers=headers, timeout=30
+        )
         if isinstance(result, str):
             return result
         try:

--- a/windows_voice_chat.py
+++ b/windows_voice_chat.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 import re
 import tempfile
@@ -93,7 +92,7 @@ class VoiceChatApp:
 
         # Fetch available models
         try:
-            self.models = asyncio.run(self.client.fetch_models())
+            self.models = self.client.fetch_models()
         except Exception:
             self.models = [{"name": self.config.default_model, "description": ""}]
         self.model_descriptions = {
@@ -475,8 +474,8 @@ class VoiceChatApp:
             + messages[1:]
         )
         try:
-            response = asyncio.run(
-                self.client.send_message(request_messages, self.selected_model.get())
+            response = self.client.send_message(
+                request_messages, self.selected_model.get()
             )
         except Exception as e:
             self._append_text("System", f"Error contacting API: {e}")


### PR DESCRIPTION
## Summary
- remove asyncio-based HTTP client in favor of `requests`
- adjust voice chat app to use new synchronous API methods

## Testing
- `python -m py_compile api_client.py windows_voice_chat.py`


------
https://chatgpt.com/codex/tasks/task_b_68b09c908f1c8329a5756a6d3c0438f3