### PR TITLE
Restore neon header and dark panels

### DIFF
--- a/windows_voice_chat.py
+++ b/windows_voice_chat.py
@@ -115,17 +115,16 @@ class VoiceChatApp:
 
     def _build_ui(self):
         # Header with title
-        header = tk.Frame(self.root, bg="black", padx=5, pady=5)
+        header = ttk.Frame(self.root, padding=5, style="Neon.TFrame")
         header.pack(fill=tk.X)
-        tk.Label(
+        ttk.Label(
             header,
             text="Unity Voice Chat",
-            fg=self.neon,
-            bg="black",
+            style="Neon.TLabel",
             font=("Segoe UI", 14, "bold"),
         ).pack(side=tk.LEFT, padx=5)
 
-        top_frame = tk.Frame(self.root, bg="black", padx=5, pady=5)
+        top_frame = ttk.Frame(self.root, padding=5, style="Neon.TFrame")
         top_frame.pack(fill=tk.X)
 
         voice_check = ttk.Checkbutton(


### PR DESCRIPTION
## Summary
- ensure app header and control panels use neon-green text with black backgrounds by applying Neon styles

## Testing
- `python -m py_compile windows_voice_chat.py`


------
https://chatgpt.com/codex/tasks/task_b_68b0a1ec62e4832985ff5f7ac30a2da9