### PR TITLE
Handle async fetch_models in Windows chat

### DIFF
--- a/windows_voice_chat.py
+++ b/windows_voice_chat.py
@@ -8,6 +8,9 @@ from tkinter import filedialog
 from io import BytesIO
 import urllib.parse
 
+import asyncio
+import inspect
+
 import requests
 import ttkbootstrap as ttk
 from ttkbootstrap.scrolled import ScrolledText
@@ -93,6 +96,8 @@ class VoiceChatApp:
         # Fetch available models
         try:
             self.models = self.client.fetch_models()
+            if inspect.isawaitable(self.models):
+                self.models = asyncio.run(self.models)
         except Exception:
             self.models = [{"name": self.config.default_model, "description": ""}]
         self.model_descriptions = {


### PR DESCRIPTION
## Summary
- Allow `windows_voice_chat.py` to work whether `APIClient.fetch_models` is async or sync by checking for awaitable and running as needed.
- Import `asyncio` and `inspect` to support the new awaitable check.

## Testing
- `python -m py_compile windows_voice_chat.py api_client.py && echo 'py_compile succeeded'`


------
https://chatgpt.com/codex/tasks/task_b_68b0ac56045483298ee7b80db4d9ab09