### PR TITLE
Handle closed event loop in voice chat app

### DIFF
--- a/api_client.py
+++ b/api_client.py
@@ -3,6 +3,7 @@ import random
 import time
 from typing import Any, Dict, List
 
+import asyncio
 import requests
 
 logger = logging.getLogger(__name__)
@@ -36,6 +37,15 @@ class APIClient:
                 )
                 time.sleep(delay)
                 continue
+            except RuntimeError as e:
+                if "Event loop is closed" in str(e):
+                    logger.warning("Event loop closed, recreating loop and retrying")
+                    asyncio.set_event_loop(asyncio.new_event_loop())
+                    delay = self.retry_delay * (2 ** attempt) + random.uniform(0, 0.1)
+                    time.sleep(delay)
+                    continue
+                logger.error(f"Unexpected runtime error {e}")
+                return f"Error: Unexpected runtime error {e}"
             except Exception as e:
                 logger.error(f"Unexpected exception {e}")
                 return f"Error: Unexpected exception {e}"

--- a/windows_voice_chat.py
+++ b/windows_voice_chat.py
@@ -8,8 +8,6 @@ from tkinter import filedialog
 from io import BytesIO
 import urllib.parse
 
-import asyncio
-import inspect
 
 import requests
 import ttkbootstrap as ttk
@@ -96,8 +94,6 @@ class VoiceChatApp:
         # Fetch available models
         try:
             self.models = self.client.fetch_models()
-            if inspect.isawaitable(self.models):
-                self.models = asyncio.run(self.models)
         except Exception:
             self.models = [{"name": self.config.default_model, "description": ""}]
         self.model_descriptions = {
@@ -506,15 +502,6 @@ class VoiceChatApp:
             response = self.client.send_message(
                 request_messages, self.selected_model.get()
             )
-            if inspect.isawaitable(response):
-                try:
-                    response = asyncio.run(response)
-                except RuntimeError:
-                    loop = asyncio.new_event_loop()
-                    try:
-                        response = loop.run_until_complete(response)
-                    finally:
-                        loop.close()
         except Exception as e:
             self._append_text("System", f"Error contacting API: {e}")
             self.ignore_mic = False


### PR DESCRIPTION
## Summary
- Avoid premature event loop closure by removing unused async handling in the GUI
- Recreate a closed asyncio loop when API requests encounter a `RuntimeError`

## Testing
- `python -m py_compile windows_voice_chat.py api_client.py`


------
https://chatgpt.com/codex/tasks/task_b_68b0afb309948329b9a282bb64629e83