### PR TITLE
Remove intermediary message filtering

### DIFF
--- a/windows_voice_chat.py
+++ b/windows_voice_chat.py
@@ -106,7 +106,6 @@ class VoiceChatApp:
 
         # Keep references to images inserted in the chat to avoid garbage collection
         self._image_refs: list[ImageTk.PhotoImage] = []
-        self.memories: list[str] = []
 
         # Audio control
         self.stop_audio = False
@@ -471,14 +470,9 @@ class VoiceChatApp:
                     self._append_text("System", f"Speech recognition error: {e}")
 
     def _get_response(self, messages):
-        request_messages = (
-            messages[:1]
-            + [{"role": "system", "content": m} for m in self.memories]
-            + messages[1:]
-        )
         try:
             response = self.client.send_message(
-                request_messages, self.selected_model.get()
+                messages, self.selected_model.get()
             )
         except Exception as e:
             self._append_text("System", f"Error contacting API: {e}")
@@ -488,7 +482,7 @@ class VoiceChatApp:
         cleaned, image_urls, code_blocks, memories = self._build_message(response)
         self.messages.append({"role": "assistant", "content": cleaned})
         for mem in memories:
-            self.memories.append(mem)
+            self.messages.append({"role": "system", "content": mem})
             self._append_text("System", f"Saved memory: {mem}")
         if cleaned:
             self._append_text("AI", cleaned)


### PR DESCRIPTION
## Summary
- Send conversation history directly to the API without injecting additional system messages
- Store saved memories in the chat history so they persist without extra filtering layer

## Testing
- `python -m py_compile app_config.py api_client.py windows_voice_chat.py`


------
https://chatgpt.com/codex/tasks/task_b_68b0b91fe3e4832998cb7150192bf17c