### PR TITLE
Fix undefined request_messages error and restore Unity default model

### DIFF
--- a/app_config.py
+++ b/app_config.py
@@ -24,3 +24,4 @@ class Config:
             self.system_instructions = ""
         self.api_url = "https://text.pollinations.ai/openai"
         self.models_url = "https://text.pollinations.ai/models"
+        self.default_model = "unity"

--- a/windows_voice_chat.py
+++ b/windows_voice_chat.py
@@ -56,7 +56,9 @@ class VoiceChatApp:
         self.voice_enabled = tk.BooleanVar(value=True)
         self.selected_voice = tk.StringVar()
         self.models = self.client.fetch_models()
-        self.selected_model = tk.StringVar(value=self.models[0])
+        if self.config.default_model not in self.models:
+            self.models.insert(0, self.config.default_model)
+        self.selected_model = tk.StringVar(value=self.config.default_model)
         self.messages = [
             {"role": "system", "content": self.config.system_instructions}
         ]
@@ -387,8 +389,6 @@ class VoiceChatApp:
 
     def _get_response(self, messages):
         try:
-            response = self.client.send_message(request_messages, self.selected_model.get())
-
             response = self.client.send_message(
                 messages, self.selected_model.get()
             )


### PR DESCRIPTION
## Summary
- remove stray request_messages call causing API failure
- default to Unity model while allowing selection of other models

## Testing
- `python -m py_compile app_config.py windows_voice_chat.py`


------
https://chatgpt.com/codex/tasks/task_b_68b0c0b250f88329b2eeb6fca5f4c99f