### PR TITLE
Handle empty assistant messages

### DIFF
--- a/api_client.py
+++ b/api_client.py
@@ -69,7 +69,14 @@ class APIClient:
         return ["unity"]
 
     def send_message(self, messages: list, model: str):
-        payload = {"messages": messages, "model": model}
+        filtered: List[Dict[str, str]] = []
+        for m in messages:
+            content = m.get("content")
+            if isinstance(content, str) and content.strip():
+                filtered.append({"role": m.get("role", ""), "content": content})
+            else:
+                logger.debug(f"Skipping empty message: {m}")
+        payload = {"messages": filtered, "model": model}
         headers = {"Authorization": f"Bearer {self.config.pollinations_token}"}
         result = self._request_json(
             "POST", self.config.api_url, json=payload, headers=headers, timeout=30

--- a/windows_voice_chat.py
+++ b/windows_voice_chat.py
@@ -398,7 +398,10 @@ class VoiceChatApp:
             return
 
         cleaned, image_urls, code_blocks, memories = self._build_message(response)
-        self.messages.append({"role": "assistant", "content": cleaned})
+        assistant_content = (
+            cleaned if cleaned else ("[Image]" if image_urls else "[No content]")
+        )
+        self.messages.append({"role": "assistant", "content": assistant_content})
         for mem in memories:
             self.messages.append({"role": "system", "content": mem})
             self._append_text("System", f"Saved memory: {mem}")


### PR DESCRIPTION
## Summary
- Skip empty messages before calling the Pollinations API
- Record placeholder content for image-only responses to avoid invalid history entries

## Testing
- `pip install -r requirements.txt` *(fails: Missing portaudio headers for pyaudio)*
- `pip install requests python-dotenv pillow gtts ttkbootstrap SpeechRecognition pyttsx3`
- `python -m py_compile api_client.py windows_voice_chat.py app_config.py`
- `python - <<'PY'\nfrom app_config import Config\nfrom api_client import APIClient\ncfg=Config()\nclient=APIClient(cfg)\nmsgs=[{"role":"user","content":"Generate a small kitten image"}]\nprint(client.send_message(msgs, cfg.default_model)[:200])\nPY`
- `python - <<'PY'\nfrom app_config import Config\nfrom api_client import APIClient\ncfg=Config()\nclient=APIClient(cfg)\nmsgs=[{"role":"assistant","content":""},{"role":"user","content":"hi"}]\nprint(client.send_message(msgs, cfg.default_model)[:100])\nPY`

------
https://chatgpt.com/codex/tasks/task_b_68b0c6af6b588329acdd506493966bcc